### PR TITLE
Fix TGConnection/Socket namespace

### DIFF
--- a/src/TGConnection/Socket/ProxySocket.php
+++ b/src/TGConnection/Socket/ProxySocket.php
@@ -5,11 +5,11 @@ namespace TGConnection\Socket;
 
 use Exception\TGException;
 use LibConfig;
-use Socks5Socket;
-use SocksException;
-use SocksProxy;
-use SocksProxyForProxy;
 use TGConnection\DataCentre;
+use TGConnection\Socket\Socks5Socket\Socks5Socket;
+use TGConnection\Socket\Socks5Socket\SocksException;
+use TGConnection\Socket\Socks5Socket\SocksProxy;
+use TGConnection\Socket\Socks5Socket\SocksProxyForProxy;
 use Tools\Proxy;
 
 

--- a/src/TGConnection/Socket/Socks5Socket/Socks5Socket.php
+++ b/src/TGConnection/Socket/Socks5Socket/Socks5Socket.php
@@ -1,4 +1,5 @@
 <?php
+namespace TGConnection\Socket\Socks5Socket;
 
 /**
  * Manage native socket as socks5-connected socket.

--- a/src/TGConnection/Socket/Socks5Socket/SocksException.php
+++ b/src/TGConnection/Socket/Socks5Socket/SocksException.php
@@ -1,5 +1,7 @@
 <?php
+namespace TGConnection\Socket\Socks5Socket;
 
+use Exception;
 
 class SocksException extends Exception
 {

--- a/src/TGConnection/Socket/Socks5Socket/SocksProxy.php
+++ b/src/TGConnection/Socket/Socks5Socket/SocksProxy.php
@@ -1,5 +1,5 @@
 <?php
-
+namespace TGConnection\Socket\Socks5Socket;
 
 interface SocksProxy
 {

--- a/src/TGConnection/Socket/Socks5Socket/SocksProxyForProxy.php
+++ b/src/TGConnection/Socket/Socks5Socket/SocksProxyForProxy.php
@@ -1,5 +1,5 @@
 <?php
-
+namespace TGConnection\Socket\Socks5Socket;
 
 use Tools\Proxy;
 


### PR DESCRIPTION
Some classes were assigned to global namespace, now fixed.