### PR TITLE
Controllable proxy timeout; TGException instead of SocksException

### DIFF
--- a/src/Client/BasicClient/BasicClientImpl.php
+++ b/src/Client/BasicClient/BasicClientImpl.php
@@ -49,13 +49,16 @@ class BasicClientImpl implements BasicClient, MessageListener
     private $authKey;
     /** @var Socket|null */
     private $socket;
+    /** @var int seconds */
+    private $proxyTimeout;
 
-    public function __construct()
+    public function __construct(int $proxyTimeout = LibConfig::CONN_SOCKET_PROXY_TIMEOUT_SEC)
     {
         $this->lastPingTime = 0;
         $this->lastIncomingMessageReceiptTime = time();
         $this->lastStatusOnlineSet = 0;
         $this->isLoggedIn = false;
+        $this->proxyTimeout = $proxyTimeout;
     }
 
     /**
@@ -143,7 +146,7 @@ class BasicClientImpl implements BasicClient, MessageListener
     {
         if($proxy instanceof Proxy){
             if($proxy->getType() == Proxy::TYPE_SOCKS5)
-                return new ProxySocket($proxy, $dc, $cb);
+                return new ProxySocket($proxy, $dc, $cb, $this->proxyTimeout);
         }
 
         return new TcpSocket($dc);

--- a/src/Exception/TGException.php
+++ b/src/Exception/TGException.php
@@ -102,7 +102,7 @@ class TGException extends Exception
     const ERR_PROXY_CONNECTION_NOT_ESTABLISHED                                 = 1004000;
     const ERR_PROXY_BAD_FORMAT                                                 = 1005000;
     const ERR_PROXY_AUTH_FAILED                                                = 1006000;
-
+    const ERR_PROXY_LONG_STEP                                                  = 1007000;
 
     /**
      * TGException constructor.


### PR DESCRIPTION
Now we have an ability to set proxy connection/response timeout.