### PR TITLE
Require APP_API_ID/APP_API_HASH as env variables

### DIFF
--- a/src/Client/AuthKey/Versions/AuthKey_v2.php
+++ b/src/Client/AuthKey/Versions/AuthKey_v2.php
@@ -63,7 +63,7 @@ class AuthKey_v2 implements AuthKey
     {
         $metaInfo = [
             'created' => time(),
-            'api_id'  => LibConfig::APP_API_ID,
+            'api_id'  => getenv('APP_API_ID'),
             'dc_id'   => $dc->getDcId(),
             'dc_ip'   => $dc->getDcIp(),
             'dc_port' => $dc->getDcPort(),

--- a/src/LibConfig.php
+++ b/src/LibConfig.php
@@ -33,16 +33,6 @@ class LibConfig
     const DC_DEFAULT_PORT = 443;
     const DC_DEFAULT_ID = 2;
 
-    /* ================================================================ Api keys */
-
-    // Official App
-    const APP_API_HASH = '014b35b6184100b085b0d0572f9b5103';
-    const APP_API_ID = 4;
-
-    //  Any Custom App
-    const OWN_API_HASH = '1fe17cda7d355166cdaa71f04122873c';
-    const OWN_API_ID = 25628;
-
     /* ================================================================  Default client info */
 
     const APP_DEFAULT_DEVICE_LANG_CODE = 'en-us';

--- a/src/TLMessage/TLMessage/ClientMessages/TgApp/init_connection.php
+++ b/src/TLMessage/TLMessage/ClientMessages/TgApp/init_connection.php
@@ -51,7 +51,7 @@ class init_connection implements TLClientMessage
         return
             Packer::packConstructor(self::CONSTRUCTOR).
             Packer::packInt($flags).
-            Packer::packInt(LibConfig::APP_API_ID).
+            Packer::packInt(getenv('APP_API_ID')).
             Packer::packString($this->account->getDevice()).
             Packer::packString($this->account->getAndroidSdkVersion()).
             Packer::packString($this->account->getAppVersion().' ('.$this->account->getAppVersionCode().')').

--- a/src/TLMessage/TLMessage/ClientMessages/TgApp/send_sms_code.php
+++ b/src/TLMessage/TLMessage/ClientMessages/TgApp/send_sms_code.php
@@ -2,7 +2,6 @@
 
 namespace TelegramOSINT\TLMessage\TLMessage\ClientMessages\TgApp;
 
-use TelegramOSINT\LibConfig;
 use TelegramOSINT\TLMessage\TLMessage\Packer;
 use TelegramOSINT\TLMessage\TLMessage\TLClientMessage;
 
@@ -39,11 +38,13 @@ class send_sms_code implements TLClientMessage
      */
     public function toBinary()
     {
+        $apiId = getenv('APP_API_ID');
+
         return
             Packer::packConstructor(self::CONSTRUCTOR).
             Packer::packString($this->phone).
-            Packer::packInt(LibConfig::APP_API_ID).
-            Packer::packString(LibConfig::APP_API_HASH).
+            Packer::packInt($apiId).
+            Packer::packString(getenv('APP_API_HASH')).
             Packer::packBytes((new send_sms_code_settings())->toBinary());
     }
 }

--- a/tests/Unit/TLMessage/TLMessage/ClientMessages/TgAppSerializationTest.php
+++ b/tests/Unit/TLMessage/TLMessage/ClientMessages/TgAppSerializationTest.php
@@ -75,6 +75,7 @@ class TgAppSerializationTest extends TestCase
 
     public function test_send_sms_code_serialization(): void
     {
+
         $this->assertStringStartsWith(
             '4f2477a60a33323533323435333432000400000020303134623335623631383431303062303835623064303537326639623531303300000083bebede10000000',
             bin2hex((new send_sms_code('3253245342'))->toBinary())

--- a/tests/phpunit.config.xml
+++ b/tests/phpunit.config.xml
@@ -8,4 +8,8 @@
   <logging>
     <log type="coverage-clover" target="coverage.xml"/>
   </logging>
+  <php>
+    <env name="APP_API_ID" value="4" force="true" />
+    <env name="APP_API_HASH" value="014b35b6184100b085b0d0572f9b5103" force="true" />
+  </php>
 </phpunit>

--- a/tools/ConstantCodesGeneration.php
+++ b/tools/ConstantCodesGeneration.php
@@ -1,7 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
-require_once __DIR__.'/../../vendor/autoload.php';
+require_once __DIR__.'/../vendor/autoload.php';
 
 use TelegramOSINT\Exception\TGException;
 
@@ -10,7 +11,7 @@ $localCounter = 0;
 
 foreach((new TGException())->getConstants() as $code => $constant){
 
-    if($code >= $codeGroup+100000) {
+    if($code >= $codeGroup + 100000) {
         $codeGroup += 100000;
         $localCounter = 0;
         echo "\n";
@@ -21,5 +22,5 @@ foreach((new TGException())->getConstants() as $code => $constant){
 
     $name = 'const '.$constant;
     $len = strlen($name);
-    echo $name . str_pad('', 75-$len, " ") . '= '.$calculatedCode.";\n";
+    echo $name.str_pad('', 75 - $len, ' ').'= '.$calculatedCode.";\n";
 }


### PR DESCRIPTION
Remove APP_API_ID/APP_API_HASH from config.
WARNING: this is incompatible change, review carefully before merge.