### PR TITLE
Feature/refactor poll and terminate

### DIFF
--- a/src/Scenario/CommonChatsScenario.php
+++ b/src/Scenario/CommonChatsScenario.php
@@ -70,21 +70,18 @@ class CommonChatsScenario extends InfoClientScenario
             }
         }
 
-        $this->login();
-        usleep(10000);
+        $this->authAndPerformActions(function (): void {
+            usleep(10000);
 
-        $this->subscribeToChats(function () {
-            Logger::log(__CLASS__, 'subscription complete');
-            $this->getCommonChats(function () {
-                Logger::log(__CLASS__, 'Common chats: '.print_r($this->commonChats, true));
+            $this->subscribeToChats(function () {
+                Logger::log(__CLASS__, 'subscription complete');
+                $this->getCommonChats(function () {
+                    Logger::log(__CLASS__, 'Common chats: '.print_r($this->commonChats, true));
 
-                $this->getInterest();
+                    $this->getInterest();
+                });
             });
-        });
-
-        if ($pollAndTerminate) {
-            $this->pollAndTerminate();
-        }
+        }, $pollAndTerminate);
     }
 
     /**

--- a/src/Scenario/GeoSearchScenario.php
+++ b/src/Scenario/GeoSearchScenario.php
@@ -51,51 +51,51 @@ class GeoSearchScenario extends InfoClientScenario
      */
     public function startActions(bool $pollAndTerminate = true): void
     {
-        $this->login();
-        $lastCb = null;
-        foreach($this->points as $point) {
-            [$lat, $lon] = $point;
-            if ($this->counter > $this->limit) {
-                break;
+        $actions = function (): void {
+            $lastCb = null;
+            foreach ($this->points as $point) {
+                [$lat, $lon] = $point;
+                if ($this->counter > $this->limit) {
+                    break;
+                }
+                $lastCb = function () use ($lat, $lon, $lastCb) {
+                    $onComplete = function (AnonymousMessage $message) use ($lat, $lon, $lastCb) {
+                        /** @see https://core.telegram.org/constructor/updates */
+                        if (!Updates::isIt($message)) {
+                            return;
+                        }
+
+                        $updates = new Updates($message);
+
+                        foreach ($updates->getChats() as $chat) {
+                            $this->counter++;
+                            if ($this->counter > $this->limit) {
+                                break;
+                            }
+                            $latF = number_format($lat, self::DECIMALS);
+                            $lonF = number_format($lon, self::DECIMALS);
+                            Logger::log(__CLASS__, "found group '{$chat->title}' near ($latF, $lonF)");
+                            $chatModel = GeoChannelModel::of($chat, $lat, $lon);
+                            if ($this->onChatReady) {
+                                $onChatReady = $this->onChatReady;
+                                $onChatReady($chatModel);
+                            }
+                        }
+
+                        usleep(700 * 1000);
+                        if ($lastCb) {
+                            $lastCb();
+                        }
+                    };
+                    $this->infoClient->getLocated($lat, $lon, $onComplete);
+                };
             }
-            $lastCb = function () use ($lat, $lon, $lastCb) {
-                $this->infoClient->getLocated($lat, $lon, function (AnonymousMessage $message) use ($lat, $lon, $lastCb) {
-                    /** @see https://core.telegram.org/constructor/updates */
-                    if (!Updates::isIt($message)) {
-                        return;
-                    }
 
-                    $updates = new Updates($message);
+            if ($lastCb) {
+                $lastCb();
+            }
+        };
 
-                    foreach ($updates->getChats() as $chat) {
-                        $this->counter++;
-                        if ($this->counter > $this->limit) {
-                            break;
-                        }
-                        $latF = number_format($lat, self::DECIMALS);
-                        $lonF = number_format($lon, self::DECIMALS);
-                        Logger::log(__CLASS__, "found group '{$chat->title}' near ($latF, $lonF)");
-                        $chatModel = GeoChannelModel::of($chat, $lat, $lon);
-                        if ($this->onChatReady) {
-                            $onChatReady = $this->onChatReady;
-                            $onChatReady($chatModel);
-                        }
-                    }
-
-                    usleep(700 * 1000);
-                    if ($lastCb) {
-                        $lastCb();
-                    }
-                });
-            };
-        }
-
-        if ($lastCb) {
-            $lastCb();
-        }
-
-        if ($pollAndTerminate) {
-            $this->pollAndTerminate();
-        }
+        $this->authAndPerformActions($actions, $pollAndTerminate);
     }
 }

--- a/src/Scenario/GroupMessagesScenario.php
+++ b/src/Scenario/GroupMessagesScenario.php
@@ -95,20 +95,18 @@ class GroupMessagesScenario extends InfoClientScenario
      */
     public function startActions(bool $pollAndTerminate = true): void
     {
-        $this->login();
-        usleep(10000);
-        $limit = 100;
-        if ($this->username) {
-            $this->infoClient->resolveUsername($this->username, $this->getUserResolveHandler(function () use ($limit) {
+        $this->authAndPerformActions(function (): void {
+            usleep(10000);
+            $limit = 100;
+            $parseMsgCallback = function () use ($limit): void {
                 $this->parseMessages($this->groupIdObj->getGroupId(), $this->groupIdObj->getAccessHash(), $limit);
-            }));
-        } else {
-            $this->parseMessages($this->groupIdObj->getGroupId(), $this->groupIdObj->getAccessHash(), $limit);
-        }
-
-        if ($pollAndTerminate) {
-            $this->pollAndTerminate();
-        }
+            };
+            if ($this->username) {
+                $this->infoClient->resolveUsername($this->username, $this->getUserResolveHandler($parseMsgCallback));
+            } else {
+                $parseMsgCallback();
+            }
+        }, $pollAndTerminate);
     }
 
     /**
@@ -118,21 +116,20 @@ class GroupMessagesScenario extends InfoClientScenario
      */
     public function startLinkParse(bool $pollAndTerminate = true): void
     {
-        $this->login();
-        usleep(10000);
-        $limit = 100;
+        $this->authAndPerformActions(function (): void {
+            usleep(10000);
+            $limit = 100;
 
-        if ($this->username) {
-            $this->infoClient->resolveUsername($this->username, $this->getUserResolveHandler(function () use ($limit) {
+            $parseLinksCallback = function () use ($limit) {
                 $this->parseLinks($this->groupIdObj->getGroupId(), $this->groupIdObj->getAccessHash(), $limit);
-            }));
-        } else {
-            $this->parseLinks($this->groupIdObj->getGroupId(), $this->groupIdObj->getAccessHash(), $limit);
-        }
+            };
 
-        if ($pollAndTerminate) {
-            $this->pollAndTerminate();
-        }
+            if ($this->username) {
+                $this->infoClient->resolveUsername($this->username, $this->getUserResolveHandler($parseLinksCallback));
+            } else {
+                $parseLinksCallback();
+            }
+        }, $pollAndTerminate);
     }
 
     private function parseLinks(int $id, int $accessHash, int $limit): void

--- a/src/Scenario/GroupResolverScenario.php
+++ b/src/Scenario/GroupResolverScenario.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TelegramOSINT\Scenario;
 
+use LogicException;
 use TelegramOSINT\Exception\TGException;
 use TelegramOSINT\MTSerialization\AnonymousMessage;
 use TelegramOSINT\Scenario\Models\GroupRequest;
@@ -82,16 +83,13 @@ class GroupResolverScenario extends InfoClientScenario
      */
     public function startActions(bool $pollAndTerminate = true): void
     {
-        $this->login();
-        if ($this->groupRequest->getUserName()) {
-            $this->infoClient->resolveUsername($this->groupRequest->getUserName(), $this->getGroupResolveHandler());
-        } else {
-            // TODO
-            throw new \LogicException('Not implemented');
-        }
-
-        if ($pollAndTerminate) {
-            $this->pollAndTerminate();
-        }
+        $this->authAndPerformActions(function (): void {
+            if ($this->groupRequest->getUserName()) {
+                $this->infoClient->resolveUsername($this->groupRequest->getUserName(), $this->getGroupResolveHandler());
+            } else {
+                // TODO
+                throw new LogicException('Not implemented');
+            }
+        }, $pollAndTerminate);
     }
 }

--- a/src/Scenario/InfoClientScenario.php
+++ b/src/Scenario/InfoClientScenario.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace TelegramOSINT\Scenario;
 
+use function call_user_func;
+use function microtime;
 use TelegramOSINT\Client\AuthKey\AuthKeyCreator;
 use TelegramOSINT\Client\InfoObtainingClient\InfoClient;
 use TelegramOSINT\Exception\TGException;
+use function usleep;
 
 abstract class InfoClientScenario implements ScenarioInterface
 {
@@ -82,6 +85,36 @@ abstract class InfoClientScenario implements ScenarioInterface
         }
     }
 
+    /**
+     * Wraps authentication/login and pollAndTerminate with a given actions callable.
+     *
+     * @param callable $actions
+     * @param bool     $pollAndTerminate
+     * @param float    $timeout
+     * @param bool     $terminate
+     *
+     * @throws TGException
+     *
+     * @return void
+     */
+    protected function authAndPerformActions(
+        callable $actions,
+        bool $pollAndTerminate = true,
+        float $timeout = 0,
+        bool $terminate = true
+    ): void {
+        $this->login();
+
+        call_user_func($actions);
+
+        if ($pollAndTerminate) {
+            $this->pollAndTerminate($timeout, $terminate);
+        }
+    }
+
+    /**
+     * @return ClientGeneratorInterface
+     */
     protected function getGenerator(): ClientGeneratorInterface
     {
         return $this->generator;

--- a/src/Scenario/UserContactsScenario.php
+++ b/src/Scenario/UserContactsScenario.php
@@ -60,10 +60,9 @@ class UserContactsScenario extends InfoClientScenario
     }
 
     /**
-     * @param string[]      $numbers
-     * @param bool          $withPhoto
-     * @param bool          $largePhoto
-     * @param callable|null $callback   function(UserInfoModel[])
+     * @param string[] $numbers
+     * @param bool     $withPhoto
+     * @param bool     $largePhoto
      */
     public function parseNumbers(array $numbers, bool $withPhoto = false, bool $largePhoto = false): void
     {
@@ -104,14 +103,12 @@ class UserContactsScenario extends InfoClientScenario
      */
     public function startActions(bool $pollAndTerminate = true): void
     {
-        $this->login();
-        $this->getContactsInfo();
-        foreach ($this->callQueue as $cb) {
-            $cb();
-        }
-        $this->callQueue = [];
-        if ($pollAndTerminate) {
-            $this->pollAndTerminate();
-        }
+        $this->authAndPerformActions(function (): void {
+            $this->getContactsInfo();
+            foreach ($this->callQueue as $cb) {
+                $cb();
+            }
+            $this->callQueue = [];
+        }, $pollAndTerminate);
     }
 }


### PR DESCRIPTION
Refactor login with poll & terminate common methods sequence
- add `InfoClientScenario::authAndPerformActions` that wraps login with poll & terminate and allows multiple usages within a scenario;
- add `authAndPerformActions` to scenarios where applicable.