### PR TITLE
Fix picture fetch from foreign DC

### DIFF
--- a/src/TLMessage/TLMessage/MessageWithUserId.php
+++ b/src/TLMessage/TLMessage/MessageWithUserId.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TelegramOSINT\TLMessage\TLMessage;
+
+interface MessageWithUserId
+{
+    public function getUserId(): int;
+}

--- a/src/TLMessage/TLMessage/ServerMessages/AuthorizationSelfUser.php
+++ b/src/TLMessage/TLMessage/ServerMessages/AuthorizationSelfUser.php
@@ -6,6 +6,8 @@ namespace TelegramOSINT\TLMessage\TLMessage\ServerMessages;
 
 use TelegramOSINT\Exception\TGException;
 use TelegramOSINT\MTSerialization\AnonymousMessage;
+use TelegramOSINT\TLMessage\TLMessage\MessageWithUserId;
+use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\ContactUser;
 use TelegramOSINT\TLMessage\TLMessage\TLServerMessage;
 
 class AuthorizationSelfUser extends TLServerMessage
@@ -23,12 +25,14 @@ class AuthorizationSelfUser extends TLServerMessage
     /**
      * @throws TGException
      *
-     * @return UserSelf
+     * @return ContactUser
      */
-    public function getUser(): UserSelf
+    public function getUser(): MessageWithUserId
     {
         $self = $this->getTlMessage()->getNode('user');
 
-        return new UserSelf($self);
+        return ContactUser::isIt($self)
+            ? new ContactUser($self)
+            : new UserSelf($self);
     }
 }

--- a/src/TLMessage/TLMessage/ServerMessages/Contact/ContactUser.php
+++ b/src/TLMessage/TLMessage/ServerMessages/Contact/ContactUser.php
@@ -6,6 +6,7 @@ namespace TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact;
 
 use TelegramOSINT\Exception\TGException;
 use TelegramOSINT\MTSerialization\AnonymousMessage;
+use TelegramOSINT\TLMessage\TLMessage\MessageWithUserId;
 use TelegramOSINT\TLMessage\TLMessage\ServerMessages\ChatPhoto;
 use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Custom\UserStatus;
 use TelegramOSINT\TLMessage\TLMessage\ServerMessages\PhotoInterface;
@@ -15,7 +16,7 @@ use TelegramOSINT\TLMessage\TLMessage\TLServerMessage;
 /**
  * @see https://core.telegram.org/type/User
  */
-class ContactUser extends TLServerMessage
+class ContactUser extends TLServerMessage implements MessageWithUserId
 {
     /**
      * @param AnonymousMessage $tlMessage
@@ -70,7 +71,7 @@ class ContactUser extends TLServerMessage
 
     public function getUserId(): int
     {
-        return $this->getTlMessage()->getValue('id');
+        return (int) $this->getTlMessage()->getValue('id');
     }
 
     public function getPhone(): ?string

--- a/src/TLMessage/TLMessage/ServerMessages/UserSelf.php
+++ b/src/TLMessage/TLMessage/ServerMessages/UserSelf.php
@@ -6,10 +6,11 @@ namespace TelegramOSINT\TLMessage\TLMessage\ServerMessages;
 
 use TelegramOSINT\Exception\TGException;
 use TelegramOSINT\MTSerialization\AnonymousMessage;
+use TelegramOSINT\TLMessage\TLMessage\MessageWithUserId;
 use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Custom\UserStatus;
 use TelegramOSINT\TLMessage\TLMessage\TLServerMessage;
 
-class UserSelf extends TLServerMessage
+class UserSelf extends TLServerMessage implements MessageWithUserId
 {
     /**
      * @param AnonymousMessage $tlMessage

--- a/tests/Unit/TLMessage/TLMessage/ServerMessages/UserSelfTest.php
+++ b/tests/Unit/TLMessage/TLMessage/ServerMessages/UserSelfTest.php
@@ -24,15 +24,6 @@ class UserSelfTest extends TestCase
         $this->deserializer = new OwnDeserializerMock();
     }
 
-    private function deserializeIntoComparableObject($serialized): string
-    {
-        $serialized = hex2bin($serialized);
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $object = $this->deserializer->deserialize($serialized);
-
-        return $object->getPrintable();
-    }
-
     private function getObjectWithChatPhoto(): AnonymousMessageMock
     {
         /* @noinspection PhpUnhandledExceptionInspection */
@@ -108,9 +99,6 @@ class UserSelfTest extends TestCase
      */
     public function test_get_photo(): void
     {
-        $data = '016d5cf3c8250a005dbb265ed97a077f32e5ddbd9b26674915c4b51c01000000ac7489c8642000009b266749600b4f1e8e4c9ac94750726f66697447617465202d20d18dd0bad0bed0bdd0bed0bcd0b8d0bad0b02c20d182d180d0b5d0b9d0b4d0b8d0bdd0b32c20d0b8d0bdd0b2d0b5d181d182d0b8d186d0b8d0b80a50726f66697447617465006a2753617690d653020000009ad3510f00000000bc3d020096bc0b2d98c6fe417690d653020000009ad3510f00000000be3d0200d3309f6700d1831cc1fb065a0000000015c4b51c00000000';
-        //$got = $this->deserializeIntoComparableObject($data);
-
         // Check is userProfilePhoto
         $userSelfProfile = new UserSelf($this->getObjectWithUserProfilePhoto());
         $profilePhoto = $userSelfProfile->getPhoto();


### PR DESCRIPTION
According to spec, https://core.telegram.org/constructor/auth.authorization now does not return `userSelf`: https://core.telegram.org/type/User (`user` is expected instead).