### PR TITLE
Fix ContactsKeeper reloadCurrentContacts called before connect

### DIFF
--- a/src/Client/StatusWatcherClient/ContactsKeeper.php
+++ b/src/Client/StatusWatcherClient/ContactsKeeper.php
@@ -349,13 +349,16 @@ class ContactsKeeper
         $this->contactsLoadedQueue[] = $onReloaded;
         $this->contactsLoading = true;
 
-        $this->client->getConnection()->getResponseAsync(new get_contacts(), function (AnonymousMessage $message) {
-            $users = new CurrentContacts($message);
-            $this->onContactsAdded($users->getUsers());
-            $this->contactsLoading = false;
-            $this->contactsLoaded = true;
-            $this->callOnContactsLoadedCallbacks();
-        });
+        $conn = $this->client->getConnection();
+        if ($conn) {
+            $conn->getResponseAsync(new get_contacts(), function (AnonymousMessage $message) {
+                $users = new CurrentContacts($message);
+                $this->onContactsAdded($users->getUsers());
+                $this->contactsLoading = false;
+                $this->contactsLoaded = true;
+                $this->callOnContactsLoadedCallbacks();
+            });
+        }
     }
 
     private function callOnContactsLoadedCallbacks()


### PR DESCRIPTION
Previously this call before establishing connection would result in an error.