### PR TITLE
Non-encrypted connection logging takes same logger as encrypted

### DIFF
--- a/src/Client/InfoObtainingClient/InfoClient.php
+++ b/src/Client/InfoObtainingClient/InfoClient.php
@@ -623,7 +623,7 @@ class InfoClient extends ContactKeepingClientImpl implements InfoObtainingClient
         if ($cachedAuthKeySerialized !== null) {
             $cb(AuthKeyCreator::createFromString($cachedAuthKeySerialized));
         } else {
-            $auth = new AppAuthorization($dc, $this->proxy);
+            $auth = new AppAuthorization($dc, $this->proxy, $this->generator->getLogger());
             $this->notEncryptedClients[] = $auth;
             $lastIndex = array_key_last($this->notEncryptedClients);
             $auth->createAuthKey(function (AuthKey $authKey) use ($cb, $lastIndex, $cacheKey) {

--- a/src/Scenario/BasicClientGenerator.php
+++ b/src/Scenario/BasicClientGenerator.php
@@ -44,4 +44,9 @@ class BasicClientGenerator implements BasicClientGeneratorInterface
     {
         return $this->proxy;
     }
+
+    public function getLogger(): ClientDebugLogger
+    {
+        return $this->logger;
+    }
 }

--- a/src/Scenario/BasicClientGeneratorInterface.php
+++ b/src/Scenario/BasicClientGeneratorInterface.php
@@ -3,6 +3,7 @@
 namespace TelegramOSINT\Scenario;
 
 use TelegramOSINT\Client\BasicClient\BasicClient;
+use TelegramOSINT\Logger\ClientDebugLogger;
 use TelegramOSINT\Tools\Proxy;
 
 interface BasicClientGeneratorInterface
@@ -10,4 +11,6 @@ interface BasicClientGeneratorInterface
     public function generate(bool $trace = false, bool $auxiliary = false): BasicClient;
 
     public function getProxy(): ?Proxy;
+
+    public function getLogger(): ClientDebugLogger;
 }

--- a/src/Scenario/ReusableBasicClientGenerator.php
+++ b/src/Scenario/ReusableBasicClientGenerator.php
@@ -8,7 +8,6 @@ use TelegramOSINT\Client\BasicClient\BasicClient;
 
 class ReusableBasicClientGenerator extends BasicClientGenerator
 {
-    /** @var BasicClient */
     private ?BasicClient $instance = null;
 
     public function generate(bool $trace = false, bool $aux = false): BasicClient

--- a/tests/Helpers/NullBasicClientGenerator.php
+++ b/tests/Helpers/NullBasicClientGenerator.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Helpers;
 
 use TelegramOSINT\Client\BasicClient\BasicClient;
+use TelegramOSINT\Logger\ClientDebugLogger;
+use TelegramOSINT\Logger\NullLogger;
 use TelegramOSINT\Scenario\BasicClientGeneratorInterface;
 use TelegramOSINT\Tools\Proxy;
 
@@ -12,10 +14,12 @@ class NullBasicClientGenerator implements BasicClientGeneratorInterface
 {
     /** @var array */
     private array $traceArray;
+    private ClientDebugLogger $logger;
 
     public function __construct(array $traceArray)
     {
         $this->traceArray = $traceArray;
+        $this->logger = new NullLogger();
     }
 
     public function generate(bool $trace = false, bool $auxiliary = false): BasicClient
@@ -26,5 +30,10 @@ class NullBasicClientGenerator implements BasicClientGeneratorInterface
     public function getProxy(): ?Proxy
     {
         return null;
+    }
+
+    public function getLogger(): ClientDebugLogger
+    {
+        return $this->logger;
     }
 }


### PR DESCRIPTION
- this prevents unexpected logs from appearing
