### PR TITLE
Retry info on user info request introduced

### DIFF
--- a/src/Client/ContactKeepingClientImpl.php
+++ b/src/Client/ContactKeepingClientImpl.php
@@ -114,6 +114,17 @@ abstract class ContactKeepingClientImpl extends DeferredClient implements Contac
     }
 
     /**
+     * @param callable $onComplete
+     *
+     * @throws TGException
+     */
+    public function getCurrentContacts(callable $onComplete): void
+    {
+        $this->throwIfNotLoggedIn(__METHOD__);
+        $this->contactsKeeper->getCurrentContacts($onComplete);
+    }
+
+    /**
      * @param string $message
      *
      * @throws TGException

--- a/src/Client/InfoObtainingClient/InfoClient.php
+++ b/src/Client/InfoObtainingClient/InfoClient.php
@@ -304,7 +304,7 @@ class InfoClient extends ContactKeepingClientImpl implements InfoObtainingClient
             } else {
                 $this->contactsKeeper->addNumbers([$phone], function (ImportResult $result) use ($phone, $withPhoto, $largePhoto, $onComplete) {
                     // check if failed because of network limits
-                    if(count($result->retryContacts) > 0 && strcmp($phone, $result->retryContacts[0]) == 0){
+                    if (count($result->retryContacts) > 0 && strcmp($phone, $result->retryContacts[0]) == 0) {
                         $model = new UserInfoModel();
                         $model->retry = true;
                         $onComplete($model);

--- a/src/Client/InfoObtainingClient/Models/UserInfoModel.php
+++ b/src/Client/InfoObtainingClient/Models/UserInfoModel.php
@@ -5,6 +5,8 @@ namespace TelegramOSINT\Client\InfoObtainingClient\Models;
 class UserInfoModel
 {
     public int $id;
+    // whether model was or was not built due to network limits
+    public bool $retry = false;
     public int $accessHash;
     public ?string $username = null;
     public ?string $bio = null;

--- a/src/Client/StatusWatcherClient/StatusWatcherAnalyzer.php
+++ b/src/Client/StatusWatcherClient/StatusWatcherAnalyzer.php
@@ -49,7 +49,7 @@ class StatusWatcherAnalyzer implements Analyzer
         }
 
         if (CurrentContacts::isIt($message)) {
-            $this->analyzeCurrentStatuses($message);
+            $this->analyzeCurrentContacts($message);
         }
     }
 
@@ -118,17 +118,15 @@ class StatusWatcherAnalyzer implements Analyzer
      *
      * @throws TGException
      */
-    private function analyzeCurrentStatuses(AnonymousMessage $message): void
+    private function analyzeCurrentContacts(AnonymousMessage $message): void
     {
+        // statuses
         $contacts = new CurrentContacts($message);
-        $prevContacts = $this->notifier->getCurrentContacts();
         foreach ($contacts->getUsers() as $user) {
             $this->performStatusReaction($user->getUserId(), $user->getStatus(), true);
-            if (isset($prevContacts[$user->getUserId()])
-                && $prevContacts[$user->getUserId()]->getUsername() !== $user->getUsername()) {
-                $this->notifier->onUserNameChange($user->getUserId(), $user->getUsername());
-            }
         }
+        // report contacts
+        $this->notifier->onCurrentContacts($contacts);
     }
 
     /**

--- a/src/Client/StatusWatcherClient/StatusWatcherCallbacksMiddleware.php
+++ b/src/Client/StatusWatcherClient/StatusWatcherCallbacksMiddleware.php
@@ -3,7 +3,6 @@
 namespace TelegramOSINT\Client\StatusWatcherClient;
 
 use TelegramOSINT\Client\StatusWatcherClient\Models\HiddenStatus;
-use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\ContactUser;
 use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\CurrentContacts;
 use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\ImportedContacts;
 

--- a/src/Client/StatusWatcherClient/StatusWatcherCallbacksMiddleware.php
+++ b/src/Client/StatusWatcherClient/StatusWatcherCallbacksMiddleware.php
@@ -4,6 +4,7 @@ namespace TelegramOSINT\Client\StatusWatcherClient;
 
 use TelegramOSINT\Client\StatusWatcherClient\Models\HiddenStatus;
 use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\ContactUser;
+use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\CurrentContacts;
 use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\ImportedContacts;
 
 interface StatusWatcherCallbacksMiddleware
@@ -36,8 +37,5 @@ interface StatusWatcherCallbacksMiddleware
 
     public function onUserNameChange(int $userId, ?string $username): void;
 
-    /**
-     * @return ContactUser[]
-     */
-    public function getCurrentContacts(): array;
+    public function onCurrentContacts(CurrentContacts $contacts): void;
 }

--- a/src/Client/StatusWatcherClient/StatusWatcherClient.php
+++ b/src/Client/StatusWatcherClient/StatusWatcherClient.php
@@ -365,7 +365,7 @@ class StatusWatcherClient extends ContactKeepingClientImpl implements
          * assume, that we have missed native onUserNameChange-message from server,
          * in this case we still can re-check from in-memory contacts and replenish missed callback
          */
-        $this->getCurrentContacts(function($inMemoryContacts) use ($contacts) {
+        $this->getCurrentContacts(function ($inMemoryContacts) use ($contacts) {
             foreach ($contacts->getUsers() as $user) {
                 if (isset($inMemoryContacts[$user->getUserId()])
                     && $inMemoryContacts[$user->getUserId()]->getUsername() !== $user->getUsername()) {

--- a/src/Client/StatusWatcherClient/StatusWatcherClient.php
+++ b/src/Client/StatusWatcherClient/StatusWatcherClient.php
@@ -19,6 +19,7 @@ use TelegramOSINT\Logger\ClientDebugLogger;
 use TelegramOSINT\MTSerialization\AnonymousMessage;
 use TelegramOSINT\TGConnection\SocketMessenger\MessageListener;
 use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\ContactUser;
+use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\CurrentContacts;
 use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\ImportedContacts;
 use TelegramOSINT\Tools\Clock;
 use TelegramOSINT\Tools\Proxy;
@@ -357,11 +358,20 @@ class StatusWatcherClient extends ContactKeepingClientImpl implements
         });
     }
 
-    /**
-     * @return ContactUser[]
-     */
-    public function getCurrentContacts(): array
+    // TODO: must be covered with test
+    public function onCurrentContacts(CurrentContacts $contacts): void
     {
-        return $this->contactsKeeper->getContacts();
+        /*
+         * assume, that we have missed native onUserNameChange-message from server,
+         * in this case we still can re-check from in-memory contacts and replenish missed callback
+         */
+        $this->getCurrentContacts(function($inMemoryContacts) use ($contacts) {
+            foreach ($contacts->getUsers() as $user) {
+                if (isset($inMemoryContacts[$user->getUserId()])
+                    && $inMemoryContacts[$user->getUserId()]->getUsername() !== $user->getUsername()) {
+                    $this->onUserNameChange($user->getUserId(), $user->getUsername());
+                }
+            }
+        });
     }
 }

--- a/tests/Unit/Client/StatusWatcherClient/StatusWatcherAnalyzerTest.php
+++ b/tests/Unit/Client/StatusWatcherClient/StatusWatcherAnalyzerTest.php
@@ -26,10 +26,6 @@ class StatusWatcherAnalyzerTest extends TestCase
         parent::setUp();
         $this->callbacks = $this->createMock(StatusWatcherCallbacksMiddleware::class);
         $this->analyzer = new StatusWatcherAnalyzer($this->callbacks);
-        $user = new ContactUser(AnonymousMessageMock::getContact(1, '123'));
-        $this->callbacks
-            ->method('getCurrentContacts')
-            ->willReturn([$user]);
     }
 
     /**

--- a/tests/Unit/Client/StatusWatcherClient/StatusWatcherAnalyzerTest.php
+++ b/tests/Unit/Client/StatusWatcherClient/StatusWatcherAnalyzerTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use TelegramOSINT\Client\StatusWatcherClient\StatusWatcherAnalyzer;
 use TelegramOSINT\Client\StatusWatcherClient\StatusWatcherCallbacksMiddleware;
 use TelegramOSINT\Exception\TGException;
-use TelegramOSINT\TLMessage\TLMessage\ServerMessages\Contact\ContactUser;
 
 class StatusWatcherAnalyzerTest extends TestCase
 {

--- a/tests/Unit/Client/StatusWatcherClient/StatusWatcherClientMock.php
+++ b/tests/Unit/Client/StatusWatcherClient/StatusWatcherClientMock.php
@@ -75,9 +75,4 @@ class StatusWatcherClientMock extends StatusWatcherClient
     public function onUserNameChange(int $userId, ?string $username): void
     {
     }
-
-    public function getCurrentContacts(): array
-    {
-        return [];
-    }
 }


### PR DESCRIPTION
- If network limits exceeded during user info
obtaining then UserInfoModel will contain special
field ('retry') filled accordingly
- Method getCurrentContacts added in ContactKeepingClientImpl
in order to have an opportunity to clean account up
before user info requests if too much contacts presented

---

- [ ] Tests added
