### PR TITLE
Registration timeout transitioned to user space

### DIFF
--- a/examples/registration.php
+++ b/examples/registration.php
@@ -30,7 +30,11 @@ $performReg = static function (AccountRegistrar $reg) use ($phone, &$performReg)
     });
 
     try {
-        $reg->pollMessages();
+        // expectation cycle
+        while (true) {
+            $reg->pollMessage();
+            usleep(50000);
+        }
     } catch (MigrateException $e) {
         $reg->terminate();
         if ($e->getDc()) {

--- a/src/Registration/AccountRegistrar.php
+++ b/src/Registration/AccountRegistrar.php
@@ -38,8 +38,6 @@ class AccountRegistrar implements RegisterInterface
     }
 
     /**
-     * @param int $timeoutSeconds
-     *
      * @throws TGException
      */
     public function pollMessage(): void

--- a/src/Registration/AccountRegistrar.php
+++ b/src/Registration/AccountRegistrar.php
@@ -42,9 +42,9 @@ class AccountRegistrar implements RegisterInterface
      *
      * @throws TGException
      */
-    public function pollMessages(): void
+    public function pollMessage(): void
     {
-        $this->reg->pollMessages();
+        $this->reg->pollMessage();
     }
 
     /**

--- a/src/Registration/RegisterInterface.php
+++ b/src/Registration/RegisterInterface.php
@@ -20,7 +20,7 @@ interface RegisterInterface
      */
     public function confirmPhoneWithSmsCode(string $smsCode, callable $onAuthKeyReady, bool $reReg = false): void;
 
-    public function pollMessages(): void;
+    public function pollMessage(): void;
 
     public function terminate(): void;
 }

--- a/src/Registration/RegistrationFromTgApp.php
+++ b/src/Registration/RegistrationFromTgApp.php
@@ -317,17 +317,14 @@ class RegistrationFromTgApp implements RegisterInterface, MessageListener
      *
      * @throws TGException
      */
-    public function pollMessages(): void
+    public function pollMessage(): void
     {
-        while (true) {
-            if ($this->socketMessenger) {
-                /** @noinspection UnusedFunctionResultInspection */
-                $this->socketMessenger->readMessage();
-            }
-            if ($this->baseAuth) {
-                $this->baseAuth->poll();
-            }
-            usleep(50000);
+        if ($this->socketMessenger) {
+            /** @noinspection UnusedFunctionResultInspection */
+            $this->socketMessenger->readMessage();
+        }
+        if ($this->baseAuth) {
+            $this->baseAuth->poll();
         }
     }
 

--- a/src/Registration/RegistrationFromTgApp.php
+++ b/src/Registration/RegistrationFromTgApp.php
@@ -313,8 +313,6 @@ class RegistrationFromTgApp implements RegisterInterface, MessageListener
     }
 
     /**
-     * @param int $timeoutSeconds
-     *
      * @throws TGException
      */
     public function pollMessage(): void


### PR DESCRIPTION
- Messages reading cycle now transitioned from
internal class to user space - in order to provide
user possibility to implement own timeout logic

---

- [ ] Tests added
